### PR TITLE
Remove internal scoping and add Async extension methods for validation contexts

### DIFF
--- a/FSharp.Data.Validation.sln
+++ b/FSharp.Data.Validation.sln
@@ -13,6 +13,8 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FSharp.Data.Validation.Test
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FSharp.Data.Validation.Giraffe", "src\FSharp.Data.Validation.Giraffe\FSharp.Data.Validation.Giraffe.fsproj", "{99EA41F7-1E77-4DD2-9D2E-9F7BE20441FB}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharp.Data.Validation.Async", "src\FSharp.Data.Validation.Async\FSharp.Data.Validation.Async.fsproj", "{CF59CFDC-CE24-4F02-A454-2FE0CC1A9FA9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -83,6 +85,18 @@ Global
 		{99EA41F7-1E77-4DD2-9D2E-9F7BE20441FB}.Release|x64.Build.0 = Release|Any CPU
 		{99EA41F7-1E77-4DD2-9D2E-9F7BE20441FB}.Release|x86.ActiveCfg = Release|Any CPU
 		{99EA41F7-1E77-4DD2-9D2E-9F7BE20441FB}.Release|x86.Build.0 = Release|Any CPU
+		{CF59CFDC-CE24-4F02-A454-2FE0CC1A9FA9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CF59CFDC-CE24-4F02-A454-2FE0CC1A9FA9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CF59CFDC-CE24-4F02-A454-2FE0CC1A9FA9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CF59CFDC-CE24-4F02-A454-2FE0CC1A9FA9}.Debug|x64.Build.0 = Debug|Any CPU
+		{CF59CFDC-CE24-4F02-A454-2FE0CC1A9FA9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CF59CFDC-CE24-4F02-A454-2FE0CC1A9FA9}.Debug|x86.Build.0 = Debug|Any CPU
+		{CF59CFDC-CE24-4F02-A454-2FE0CC1A9FA9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CF59CFDC-CE24-4F02-A454-2FE0CC1A9FA9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CF59CFDC-CE24-4F02-A454-2FE0CC1A9FA9}.Release|x64.ActiveCfg = Release|Any CPU
+		{CF59CFDC-CE24-4F02-A454-2FE0CC1A9FA9}.Release|x64.Build.0 = Release|Any CPU
+		{CF59CFDC-CE24-4F02-A454-2FE0CC1A9FA9}.Release|x86.ActiveCfg = Release|Any CPU
+		{CF59CFDC-CE24-4F02-A454-2FE0CC1A9FA9}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/FSharp.Data.Validation.Async/FSharp.Data.Validation.Async.fsproj
+++ b/src/FSharp.Data.Validation.Async/FSharp.Data.Validation.Async.fsproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="VCtx.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FSharp.Data.Validation\FSharp.Data.Validation.fsproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/FSharp.Data.Validation.Async/VCtx.fs
+++ b/src/FSharp.Data.Validation.Async/VCtx.fs
@@ -1,0 +1,71 @@
+namespace FSharp.Data.Validation
+
+[<RequireQualifiedAccess>]
+module VCtx =
+    /// <summary>
+    /// Binds a function that returns an asynchronous computation to a validation context.
+    /// </summary>
+    /// <remarks>
+    /// This function takes a function <c>fn</c> that transforms a value of type <c>'A</c> into an
+    /// asynchronous computation of type <c>Async&lt;VCtx&lt;'F, 'B&gt;&gt;</c> and a validation context <c>c</c>
+    /// of type <c>VCtx&lt;'F, 'A&gt;</c>. It returns an asynchronous computation of type <c>Async&lt;VCtx&lt;'F, 'B&gt;&gt;</c>.
+    ///
+    /// The function handles the following cases:
+    /// <list type="bullet">
+    /// <item>
+    /// <description><c>ValidCtx a</c>: Applies the function <c>fn</c> to <c>a</c> and returns the result.</description>
+    /// </item>
+    /// <item>
+    /// <description><c>RefutedCtx (gfs, lfs)</c>: Returns the same <c>RefutedCtx</c> without applying the function.</description>
+    /// </item>
+    /// <item>
+    /// <description><c>DisputedCtx (gfs, lfs, a)</c>: Applies the function <c>fn</c> to <c>a</c> and merges the results accordingly.</description>
+    /// </item>
+    /// </list>
+    /// </remarks>
+    /// <param name="fn">A function that takes a value of type <c>'A</c> and returns an asynchronous computation of type <c>Async&lt;VCtx&lt;'F, 'B&gt;&gt;</c>.</param>
+    /// <param name="c">A validation context of type <c>VCtx&lt;'F, 'A&gt;</c>.</param>
+    /// <returns>An asynchronous computation of type <c>Async&lt;VCtx&lt;'F, 'B&gt;&gt;</c>.</returns>
+    let bindToAsync (fn:'A -> Async<VCtx<'F, 'B>>) (c: VCtx<'F, 'A>): Async<VCtx<'F, 'B>> =
+        async {
+            match c with
+            | ValidCtx a                -> return! fn a
+            | RefutedCtx (gfs,lfs)      -> return RefutedCtx (gfs,lfs)
+            | DisputedCtx (gfs,lfs,a)   ->
+                let! b = fn a
+                match b with
+                | ValidCtx b                -> return DisputedCtx (gfs,lfs,b)
+                | DisputedCtx (gfs',lfs',b) -> return DisputedCtx (gfs @ gfs', Utilities.mergeFailures lfs lfs', b)
+                | RefutedCtx (gfs',lfs')    -> return RefutedCtx (gfs @ gfs', Utilities.mergeFailures lfs lfs')
+        }
+
+    /// <summary>
+    /// Binds a function that returns a validation context to an asynchronous computation.
+    /// </summary>
+    /// <remarks>
+    /// This function takes a function <c>fn</c> that transforms a value of type <c>'A</c> into a validation context
+    /// of type <c>VCtx&lt;'F, 'B&gt;</c> and an asynchronous computation <c>c</c> of type <c>Async&lt;VCtx&lt;'F, 'A&gt;&gt;</c>.
+    /// It returns an asynchronous computation of type <c>Async&lt;VCtx&lt;'F, 'B&gt;&gt;</c>.
+    /// </remarks>
+    /// <param name="fn">A function that takes a value of type <c>'A</c> and returns a validation context of type <c>VCtx&lt;'F, 'B&gt;</c>.</param>
+    /// <param name="c">An asynchronous computation of type <c>Async&lt;VCtx&lt;'F, 'A&gt;&gt;</c>.</param>
+    /// <returns>An asynchronous computation of type <c>Async&lt;VCtx&lt;'F, 'B&gt;&gt;</c>.</returns>
+    let bindAsync (fn:'A -> Async<VCtx<'F, 'B>>) (c: Async<VCtx<'F, 'A>>): Async<VCtx<'F, 'B>> =
+        async {
+            let! c' = c
+            return! bindToAsync fn c'
+        }
+
+    /// <summary>
+    /// Binds a function that returns a validation context to a validation context.
+    /// </summary>
+    /// <remarks>
+    /// This function takes a function <c>fn</c> that transforms a value of type <c>'A</c> into a validation context
+    /// of type <c>VCtx&lt;'F, 'B&gt;</c> and a validation context <c>c</c> of type <c>VCtx&lt;'F, 'A&gt;</c>.
+    /// It returns a validation context of type <c>VCtx&lt;'F, 'B&gt;</c>.
+    /// </remarks>
+    /// <param name="fn">A function that takes a value of type <c>'A</c> and returns a validation context of type <c>VCtx&lt;'F, 'B&gt;</c>.</param>
+    /// <param name="c">A validation context of type <c>VCtx&lt;'F, 'A&gt;</c>.</param>
+    /// <returns>A validation context of type <c>VCtx&lt;'F, 'B&gt;</c>.</returns>
+    let bindFromAsync (fn:'A -> VCtx<'F, 'B>) (c: Async<VCtx<'F, 'A>>): Async<VCtx<'F, 'B>> =
+        bindAsync (fn >> async.Return) c

--- a/src/FSharp.Data.Validation/Utilities.fs
+++ b/src/FSharp.Data.Validation/Utilities.fs
@@ -1,4 +1,4 @@
-﻿module internal FSharp.Data.Validation.Utilities
+module FSharp.Data.Validation.Utilities
 
 // Given a sequence of options, return list of Some
 let catOptions l = Seq.choose id l

--- a/src/FSharp.Data.Validation/VCtx.fs
+++ b/src/FSharp.Data.Validation/VCtx.fs
@@ -6,7 +6,6 @@ open System.Linq.Expressions
 open FSharpPlus.Data
 
 type VCtx<'F, 'A> =
-    internal
     | ValidCtx of 'A
     | DisputedCtx of 'F list * FailureMap<'F> * 'A
     | RefutedCtx of 'F list * FailureMap<'F>


### PR DESCRIPTION
### Description

Add the FSharp.Data.Validation.Async project that adds the following asynchronous functions for use with `VCtx`:
- `bindToAsync`
- `bindAsync`
- `bindFromAsync`